### PR TITLE
update for bx-GooStats. Fix NLL bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.9)
 project(GOOSTATS CXX)
 
 file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)

--- a/GooFit/src/PDFs/GooPdf.cu
+++ b/GooFit/src/PDFs/GooPdf.cu
@@ -429,7 +429,7 @@ __host__ fptype GooPdf::normalise () const {
 					thrust::make_zip_iterator(thrust::make_tuple(binIndex + totalBins, eventSize, arrayAddress)),
 					*binnedlogger, dummy, cudaPlus); 
  
-  if (::isnan(sum)) {
+  if (std::isnan(sum)) {
     abortWithCudaPrintFlush(__FILE__, __LINE__, getName() + " NaN in normalisation", this); 
   }
   else if (0 >= sum) { 

--- a/GooFit/src/goofit/FitManagerMinuit1.cc
+++ b/GooFit/src/goofit/FitManagerMinuit1.cc
@@ -93,7 +93,7 @@ void FitFun(int & __attribute__((__unused__)) npar, double * __attribute__((__un
   pars.resize(numPars); 
   int counter = 0; 
   for (auto i : FitManager::vars) {
-    if (::isnan(fp[counter])) cout << "Variable " << i->name << " " << i->index << " is NaN\n"; 
+    if (std::isnan(fp[counter])) cout << "Variable " << i->name << " " << i->index << " is NaN\n"; 
     pars[i->getIndex()] = fp[counter++] + i->blind; 
   }
   

--- a/Kernel/src/CMakeLists.txt
+++ b/Kernel/src/CMakeLists.txt
@@ -1,14 +1,11 @@
 add_library(GooStatsKernel
   RawSpectrumProvider.cc
   ParSyncManager.cc
-  NLLCheckFixture.cc
-  GooStatsNLLCheck.cc
   BasicSpectrumBuilder.cc
   TextOutputManager.cc
   OutputHelper.cc
   OptionManager.cc
   Module.cc
-  BestFitFixture.cc
   AnalysisManager.cc
   DatasetManager.cc
   BasicManagerImpl.cc
@@ -23,11 +20,14 @@ target_link_libraries(GooStatsKernel GooStatsLib_gpu)
 
 ROOT_GENERATE_DICTIONARY(G__GooStatsNLLCheck ../include/GooStatsNLLCheck.h
   LINKDEF ../include/GooStatsNLLCheckLinkDef.h)
-add_library(GooStatsNLLCheck SHARED GooStatsNLLCheck.cc G__GooStatsNLLCheck.cxx)
+add_library(GooStatsNLLCheck SHARED GooStatsNLLCheck.cc G__GooStatsNLLCheck)
 target_link_libraries(GooStatsNLLCheck ${ROOT_LIBRARIES})
 
-add_library(TestFixture BestFitFixture.cc NLLCheckFixture.cc)
-target_link_libraries(TestFixture ${ROOT_LIBRARIES})
+add_library(BestFitFixture BestFitFixture.cc)
+target_link_libraries(BestFitFixture GTest::GTest ${ROOT_LIBRARIES})
+
+add_library(NLLFixture NLLCheckFixture.cc)
+target_link_libraries(NLLFixture GooStatsNLLCheck GTest::GTest ${ROOT_LIBRARIES})
 #INSTALL(FILES ${ROOT_DICT_OUTPUT_DIR}/libGooStatsNLLCheck_rdict.pcm DESTINATION
 #  ${LIBRARY_OUTPUT_PATH})
 

--- a/Kernel/src/NLLCheckFixture.cc
+++ b/Kernel/src/NLLCheckFixture.cc
@@ -3,7 +3,10 @@
 #include "TFile.h"
 #include "TTree.h"
 
-NLLCheckFixture::NLLCheckFixture() {}
+#include "TSystem.h"
+NLLCheckFixture::NLLCheckFixture() {
+  gSystem->Load("libGooStatsNLLCheck.so");
+}
 NLLCheckFixture::~NLLCheckFixture() {}
 
 void NLLCheckFixture::SetUp() { }

--- a/Modules/naive-Reactor/CMakeLists.txt
+++ b/Modules/naive-Reactor/CMakeLists.txt
@@ -5,7 +5,3 @@ add_executable(reactor reactor.cc)
 target_compile_features(reactor PRIVATE cxx_range_for)
 target_link_libraries(reactor reactor_module)
 target_link_libraries(reactor GooStatsLib)
-
-add_test(NAME    autoTest
-           COMMAND autoTest
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Modules/naive-Reactor/Test/CMakeLists.txt
+++ b/Modules/naive-Reactor/Test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Define a test
 
 add_executable(autoTest autoTest.cc)
-target_link_libraries(autoTest PRIVATE TestFixture ${GTEST_BOTH_LIBRARIES} pthread)
+target_link_libraries(autoTest PRIVATE BestFitFixture NLLFixture ${GTEST_BOTH_LIBRARIES} pthread)
 target_link_libraries(autoTest PRIVATE reactor_module)
 target_link_libraries(autoTest PRIVATE GooStatsLib)
 if(COVERAGE OR DEFINED ENV{COVERAGE})

--- a/PDFs/include/SumPdf.h
+++ b/PDFs/include/SumPdf.h
@@ -51,7 +51,7 @@ protected:
   static std::map<BinnedDataSet*,int> maskmap;
   bool updated() const { return m_updated; }
 #ifdef NLL_CHECK
-  __host__ double sumOfNll (int numVars) const;
+  __host__ double sumOfNll (int numVars) const final;
   friend class DarkNoiseConvolutionPdf;
 #endif
   std::vector<unsigned int> pindices;

--- a/PDFs/src/CMakeLists.txt
+++ b/PDFs/src/CMakeLists.txt
@@ -20,4 +20,7 @@ goofit_add_library(GooStatsPDFs
   ResponseFunctionPdf_impl.cu
   SumLikelihoodPdf.cu
   SumPdf.cu)
+if(NLL_CHECK)
+  target_link_libraries(GooStatsPDFs GooStatsNLLCheck)
+endif()
 target_link_libraries(GooStatsPDFs GOOFIT::goofit_lib AllGPU)

--- a/PDFs/src/DarkNoiseConvolutionPdf.cu
+++ b/PDFs/src/DarkNoiseConvolutionPdf.cu
@@ -139,7 +139,7 @@ __host__ fptype DarkNoiseConvolutionPdf::sumOfNll( int numVars ) const {
     printf("log(L) %.15le b %lf M %lf tot %.15lf\n",sum,host_array[i*3],host_array[i*3+1],sumV[i]*binVolume);
   }
   if(first) { sum = 0; first = false; } else first = true;
-  delete host_array;
+  delete [] host_array;
   // debug end
   return thrust::reduce(results.begin(),results.end(),dummy,cudaPlus);
 }

--- a/PDFs/src/SumPdf.cu
+++ b/PDFs/src/SumPdf.cu
@@ -350,7 +350,7 @@ __host__ double SumPdf::sumOfNll (int numVars) const {
 //    printf("\n");
   }
   if(first) { sum = 0; first = false; } else first = true;
-  delete host_array;
+  delete [] host_array;
   // debug end
   return thrust::reduce(results.begin(),results.end(),dummy,cudaPlus);
 }

--- a/SimplePackage/include/SimplePlotManager.h
+++ b/SimplePackage/include/SimplePlotManager.h
@@ -13,9 +13,9 @@
 class SimplePlotManager : public PlotManager {
   public:
     void draw(int event,const std::vector<DatasetManager*> &datasets) final;
+    using PlotManager::draw;
   private:
     virtual std::map<std::string,std::vector<DatasetManager*>>
       groupByName(const std::vector<DatasetManager*>&);
-    using PlotManager::draw;
 };
 #endif

--- a/SimplePackage/src/CMakeLists.txt
+++ b/SimplePackage/src/CMakeLists.txt
@@ -6,4 +6,4 @@ add_library(GooStatsSimple
   SimplePlotManager.cc
   PrepareData.cc
   PullDatasetController.cc)
-target_link_libraries(GooStatsSimple GooStatsKernel)
+target_link_libraries(GooStatsSimple GooStatsKernel GooStatsPDFs)

--- a/StatModules/src/CMakeLists.txt
+++ b/StatModules/src/CMakeLists.txt
@@ -10,4 +10,4 @@ add_library(GooStatsStatModules
   OutputManager.cc
   PlotManager.cc
   ToyMCLikelihoodEvaluator.cc)
-target_link_libraries(GooStatsStatModules GooStatsKernel)
+target_link_libraries(GooStatsStatModules GooStatsKernel GOOFIT::goofit_lib)


### PR DESCRIPTION
fix bug for NLL check

for NLLCheck

add GooStatsNLLCheck libarary

link RPF

need cmake 3.9 for OpenMP

update way of linking

use dynamic

use modern cmake

use std::isnan

use std::isnan

update

should load it